### PR TITLE
Guard against empty result returned from getItemFromBlock

### DIFF
--- a/src/main/java/com/mrcrayfish/furniture/proxy/ClientProxy.java
+++ b/src/main/java/com/mrcrayfish/furniture/proxy/ClientProxy.java
@@ -17,6 +17,7 @@ import net.minecraft.client.renderer.color.IBlockColor;
 import net.minecraft.client.renderer.color.IItemColor;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.world.ColorizerFoliage;
@@ -152,8 +153,11 @@ public class ClientProxy extends CommonProxy
 
     public void registerColorHandlerForBlock(Block block, IBlockColor blockColor, IItemColor itemColor)
     {
-        FMLClientHandler.instance().getClient().getItemColors().registerItemColorHandler(itemColor, Item.getItemFromBlock(block));
-        FMLClientHandler.instance().getClient().getBlockColors().registerBlockColorHandler(blockColor, block);
+        Minecraft mc = FMLClientHandler.instance().getClient();
+        Item item = Item.getItemFromBlock(block);
+        if (item != Items.AIR)
+            mc.getItemColors().registerItemColorHandler(itemColor, item);
+        mc.getBlockColors().registerBlockColorHandler(blockColor, block);
     }
 
     @Override


### PR DESCRIPTION
Without this check, FurnitureBlocks.TREE_TOP and FurnitureBlocks.TREE_BOTTOM will return Items.AIR from getItemFromBlock, resulting in the tint handler being registered for Items.AIR, which gives all item blocks from ArchitectureCraft (and other mods) a green tint.

Before the fix:

<img width="592" height="156" alt="image" src="https://github.com/user-attachments/assets/65a6f3a2-a3f0-48ff-9df4-d66005fb1756" />

After the fix:

<img width="260" height="116" alt="image" src="https://github.com/user-attachments/assets/78d4368b-6a85-4600-8a80-28b07e656eb8" />
